### PR TITLE
Add comprehensive email pattern variations for better discovery

### DIFF
--- a/backend/src/controllers/checkEmailController.js
+++ b/backend/src/controllers/checkEmailController.js
@@ -25,15 +25,60 @@ function generateGuesses(name, domain) {
 
   for (const first of firstParts) {
     for (const last of lastParts) {
+      // Basic patterns
       guesses.add(`${first}@${domain}`);
       guesses.add(`${last}@${domain}`);
+
+      // Dot separator patterns
       guesses.add(`${first}.${last}@${domain}`);
       guesses.add(`${last}.${first}@${domain}`);
+
+      // No separator patterns
       guesses.add(`${first}${last}@${domain}`);
       guesses.add(`${last}${first}@${domain}`);
+
+      // Underscore separator patterns
+      guesses.add(`${first}_${last}@${domain}`);
+      guesses.add(`${last}_${first}@${domain}`);
+
+      // Hyphen separator patterns
+      guesses.add(`${first}-${last}@${domain}`);
+      guesses.add(`${last}-${first}@${domain}`);
+
+      // First initial + last name
       guesses.add(`${first.charAt(0)}${last}@${domain}`);
       guesses.add(`${first.charAt(0)}.${last}@${domain}`);
+      guesses.add(`${first.charAt(0)}_${last}@${domain}`);
+      guesses.add(`${first.charAt(0)}-${last}@${domain}`);
+
+      // Last initial + first name
+      guesses.add(`${last.charAt(0)}${first}@${domain}`);
+      guesses.add(`${last.charAt(0)}.${first}@${domain}`);
+      guesses.add(`${last.charAt(0)}_${first}@${domain}`);
+
+      // First name + last initial
+      guesses.add(`${first}${last.charAt(0)}@${domain}`);
+      guesses.add(`${first}.${last.charAt(0)}@${domain}`);
+      guesses.add(`${first}_${last.charAt(0)}@${domain}`);
+
+      // Last name + first initial
+      guesses.add(`${last}${first.charAt(0)}@${domain}`);
+      guesses.add(`${last}.${first.charAt(0)}@${domain}`);
+      guesses.add(`${last}_${first.charAt(0)}@${domain}`);
+
+      // Both initials
       guesses.add(`${first.charAt(0)}${last.charAt(0)}@${domain}`);
+      guesses.add(`${first.charAt(0)}.${last.charAt(0)}@${domain}`);
+      guesses.add(`${last.charAt(0)}${first.charAt(0)}@${domain}`);
+
+      // Common numbered variations (1, 01, 2)
+      guesses.add(`${first}.${last}1@${domain}`);
+      guesses.add(`${first}.${last}01@${domain}`);
+      guesses.add(`${first}.${last}2@${domain}`);
+      guesses.add(`${first}${last}1@${domain}`);
+      guesses.add(`${first.charAt(0)}${last}1@${domain}`);
+      guesses.add(`${first}1@${domain}`);
+      guesses.add(`${last}1@${domain}`);
     }
   }
 


### PR DESCRIPTION
Expanded email guessing patterns from 9 to 33+ variations per name.

New Pattern Categories Added:

1. Underscore Separators:
   - first_last@domain
   - last_first@domain
   - f_last@domain
   - first_l@domain
   - last_f@domain

2. Hyphen Separators:
   - first-last@domain
   - last-first@domain
   - f-last@domain

3. Initial Combinations:
   - First initial + last: flast, f.last, f_last, f-last
   - Last initial + first: lfirst, l.first, l_first
   - First + last initial: firstl, first.l, first_l
   - Last + first initial: lastf, last.f, last_f
   - Both initials: fl, f.l, lf

4. Numbered Variations (common in corporate):
   - first.last1, first.last01, first.last2
   - firstlast1
   - flast1
   - first1, last1

All patterns maintain existing functionality:
- Case-insensitive
- Space normalization
- Set-based deduplication
- Multi-part name support

Example for "John Doe":
Before: 9 patterns
After: 33 patterns

This significantly increases the chance of finding valid email addresses while maintaining performance through Set deduplication.